### PR TITLE
Docker metadata with IndifferentAccess

### DIFF
--- a/lib/logstash/filters/docker_hash.rb
+++ b/lib/logstash/filters/docker_hash.rb
@@ -1,0 +1,7 @@
+require 'hashie'
+
+class DockerHash < Hash
+
+  include Hashie::Extensions::IndifferentAccess
+
+end

--- a/logstash-filter-docker_metadata.gemspec
+++ b/logstash-filter-docker_metadata.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-filter-docker_metadata'
-  s.version         = '0.1.4'
+  s.version         = '0.1.5'
   s.licenses = ['Apache License (2.0)']
   s.summary = "This filter add docker metadata to messages that contain a docker ID. It's heavily inspired from https://github.com/fabric8io/fluent-plugin-docker_metadata_filter."
   s.description = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -18,10 +18,11 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-  s.add_runtime_dependency 'docker-api'  
-  s.add_runtime_dependency 'lru_redux'   
-  s.add_runtime_dependency 'json'        
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 3.0.0"
+  s.add_runtime_dependency 'docker-api'
+  s.add_runtime_dependency 'lru_redux'
+  s.add_runtime_dependency 'json'
+  s.add_runtime_dependency 'hashie'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/filters/docker_metadata_spec.rb
+++ b/spec/filters/docker_metadata_spec.rb
@@ -1,20 +1,44 @@
-require 'spec_helper'
-require "logstash/filters/dockerMetadata"
+require_relative "../spec_helper"
+require "logstash/filters/docker_metadata"
 
-describe LogStash::Filters::dockerMetadata do
-  describe "Set to Hello World" do
+describe LogStash::Filters::DockerMetadata do
+
+  let(:container_info) do
+    metadata = {}
+    metadata['id'] = "123456789"
+    metadata['Name'] = "container"
+    metadata['Image'] = "image_id"
+    metadata['Config'] = {}
+    metadata['Config']['Hostname'] = "hostname"
+    metadata['Config']['Image'] = "image"
+    metadata['Config']['Labels'] = { "label1" => "label_value"}
+    metadata['Config']['Env'] = [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "NGINX_VERSION=1.9.5-1~jessie"
+    ]
+    metadata
+  end
+
+
+  describe "Docker container metadada as symbol keys in hash by default" do
     let(:config) do <<-CONFIG
       filter {
         docker_metadata {
-          
+
         }
       }
     CONFIG
     end
 
-    sample("message" => "some text") do
-      expect(subject).to include("message")
-      expect(subject['message']).to eq('Hello World')
+    sample("path" => "/var/lib/docker/containers/d58155b6b2979776ef3594838536375ec19c6452431888f1d71bb7b2d5b8d84b/d58155b6b2979776ef3594838536375ec19c6452431888f1d71bb7b2d5b8d84b-json.log") do
+      c = double()
+      expect(Docker::Container).to receive(:get).with('d58155b6b2979776ef3594838536375ec19c6452431888f1d71bb7b2d5b8d84b').and_return(c)
+      expect(c).to receive(:info).and_return(container_info)
+
+      expect(subject['docker']).not_to be_nil
+      expect(subject['docker']['name']).to eq('container')
+      expect(subject['docker']['name']).to eq(subject['docker'][:name])
+      expect(subject['docker']['env']['NGINX_VERSION']).to eq('1.9.5-1~jessie')
     end
   end
 end


### PR DESCRIPTION
Changed the docker metadata has to use Hashie IndifferentAccess. This is because Logstash configs proved hard to work with symbolic hash keys i.e. in if/else structures. IndifferentAccess hash allows to fetch the hash value by either symbol or string. See: https://github.com/intridea/hashie#indifferentaccess
